### PR TITLE
Add TransmissionResult message

### DIFF
--- a/v3/messages.proto
+++ b/v3/messages.proto
@@ -232,7 +232,32 @@ message DownlinkMessage {
   bytes forwarder_uplink_token = 6;
   // Gateway uplink token, copied from UplinkMessage.
   bytes gateway_uplink_token = 7;
+  // Downlink token.
+  bytes downlink_token = 9;
 
   // Priority of the downlink message.
   DownlinkMessagePriority priority = 8;
+}
+
+// Transmission result.
+message TransmissionResult {
+  enum Code {
+    SUCCESS = 0;
+    UNKNOWN_ERROR = 1;
+    TOO_LATE = 2;
+    TOO_EARLY = 3;
+    COLLISION_PACKET = 4;
+    COLLISION_BEACON = 5;
+    TX_FREQUENCY = 6;
+    TX_POWER = 7;
+    GPS_UNLOCKED = 8;
+  }
+  // Result code.
+  Code code = 1;
+  // RX1 frequency.
+  google.protobuf.UInt64Value rx1_frequency = 2;
+  // RX2 frequency.
+  google.protobuf.UInt64Value rx2_frequency = 3;
+  // Downlink token copied from the DownlinkMessage.
+  bytes downlink_token = 4;
 }


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Add `TransmissionResult` message

#### Changes
<!-- What are the changes made in this pull request? -->

Add `TransmissionResult` message with codes that map 1:1 to The Things Stack

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

The ugly thing is the RX1 and RX2 frequencies. This stems from `DLFreq1` and `DLFreq2` of the `XmitDataAns` message from LoRaWAN Backend Interfaces 1.0.

Both RX1 and RX2 can be used to transmit, so both can be part of the transmission result.
