### PR TITLE
Make data rates explicit

### DIFF
--- a/v3/messages.proto
+++ b/v3/messages.proto
@@ -132,6 +132,22 @@ message GatewayMetadataLocalization {
   }
 }
 
+message LoRaDataRate {
+  uint32 spreading_factor = 1;
+  // Bandwidth (Hz).
+  uint32 bandwidth = 2;
+}
+
+message FSKDataRate {
+  uint32 bits_per_second = 1;
+}
+
+message LRFHSSDataRate {
+  uint32 modulation_type = 1;
+  // Operating channel width (Hz).
+  uint32 operating_channel_width = 2;
+}
+
 // LoRaWAN uplink data message with encrypted PHYPayload and metadata.
 message UplinkMessage {
   // Key encryption keys with which data encryption keys are encrypted.
@@ -160,8 +176,16 @@ message UplinkMessage {
   google.protobuf.Timestamp gateway_receive_time = 4;
   // Region of the gateway.
   Region gateway_region = 5;
-  // Data rate index in the gateway's region.
-  uint32 data_rate_index = 6;
+
+  oneof data_rate {
+    // Data rate index as defined in the gateway's LoRaWAN region.
+    // DEPRECATED: Specify data rate settings per modulation instead.
+    uint32 data_rate_index = 6;
+    LoRaDataRate lora_data_rate = 13;
+    FSKDataRate fsk_data_rate = 14;
+    LRFHSSDataRate lrfhss_data_rate = 15;
+  }
+
   // Frequency (Hz).
   uint64 frequency = 7;
   // Coding rate.
@@ -209,8 +233,14 @@ message DownlinkMessage {
   message RXSettings {
     // Frequency (Hz).
     uint64 frequency = 1;
-    // Data rate index as defined in the gateway's LoRaWAN region.
-    uint32 data_rate_index = 2;
+    oneof data_rate {
+      // Data rate index as defined in the gateway's LoRaWAN region.
+      // DEPRECATED: Specify data rate settings per modulation instead.
+      uint32 data_rate_index = 2;
+      LoRaDataRate lora_data_rate = 3;
+      FSKDataRate fsk_data_rate = 4;
+      LRFHSSDataRate lrfhss_data_rate = 5;
+    }
   }
   // RX1 settings.
   RXSettings rx1 = 2;


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Make data rates explicit

#### Changes
<!-- What are the changes made in this pull request? -->

- Mark `data_rate_index` on uplink and downlink message deprecated
- Introduce a new `data_rate` field that includes the transmission settings for the supported modulations