### PR TITLE
Add CN470-510 regions

### DIFF
--- a/v3/enums.proto
+++ b/v3/enums.proto
@@ -27,6 +27,14 @@ enum Region {
   EU_433 = 4;
   AU_915_928 = 5;
   CN_470_510 = 6;
+  // CN470-510 20 MHz antenna, type A
+  CN_470_510_20_A = 16;
+  // CN470-510 20 MHz antenna, type B
+  CN_470_510_20_B = 17;
+  // CN470-510 26 MHz antenna, type A
+  CN_470_510_26_A = 18;
+  // CN470-510 26 MHz antenna, type B
+  CN_470_510_26_B = 19;
   AS_923 = 7;
   // AS923 group 1
   AS_923_1 = 11;

--- a/v3/enums.proto
+++ b/v3/enums.proto
@@ -36,8 +36,7 @@ enum Region {
   // CN470-510 26 MHz antenna, type B
   CN_470_510_26_B = 19;
   AS_923 = 7;
-  // AS923 group 1
-  AS_923_1 = 11;
+  reserved 11; // Deprecated: AS_923_1
   // AS923 group 2
   AS_923_2 = 12;
   // AS923 group 3


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This PR adds the 4 CN470-510 regions found in the RP2-1.0.0 and higher Regional Parameters specifications.

#### Changes
<!-- What are the changes made in this pull request? -->

- Add the 4 regions (`CN_470_510_20_A`, `CN_470_510_20_B`, `CN_470_510_26_A`, `CN_470_510_26_B`)
- Deprecate the `AS_923_1` region, as it coincides with the `AS_923` region