### PR TITLE
Add duplicate payload uplink message processing error

### DIFF
--- a/v3/enums.proto
+++ b/v3/enums.proto
@@ -92,6 +92,8 @@ enum UplinkMessageProcessingError {
   // For join-request messages, this can be caused by the device not being registered or an already used DevNonce.
   // For data uplink messages, this can be caused by an unknown DevAddr or a MIC check failure.
   NOT_FOUND = 2;
+  // The message is a duplicate of a previously received message.
+  DUPLICATE_PAYLOAD = 5;
   // Internal error.
   UPLINK_INTERNAL = 3;
   // No Home Network endpoints found.


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

References https://github.com/TheThingsIndustries/lorawan-stack/pull/3391

#### Changes
<!-- What are the changes made in this pull request? -->

- Add the `DUPLICATE_PAYLOAD` uplink message processing error

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

I called it `duplicate_payload` in order to emphasize that the `PHYPayload` is duplicate, not the routed message itself.

#### Release Notes
<!--
NOTE: This section is optional.

Any notes that we need to include in the Release Notes for the next release.
These notes are formatted as bullet points, written in past tense, and will be
combined with the labels of this Pull Request.

Always mention changes in API.
-->

- Added the `DUPLICATE_PAYLOAD` uplink message processing error, which signals that the receiver has already received this particular `PHYPayload`.
