### PR TITLE
Add network delegation

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,3 +1,3 @@
-/ @johanstokking @htdvisser
+* @johanstokking
 /CODEOWNERS @johanstokking
 /LICENSE @johanstokking

--- a/iam/v1/service.proto
+++ b/iam/v1/service.proto
@@ -85,6 +85,12 @@ message UpdateNetworkRequest {
   // Target information.
   // This field gets updated when a value is set.
   TargetValue target = 7;
+  // Delegated network.
+  // This field gets updated when a value is set.
+  message DelegatedNetID {
+    google.protobuf.UInt32Value value = 1;
+  }
+  DelegatedNetID delegated_net_id = 8;
 }
 
 service NetworkRegistry {

--- a/v3/messages.proto
+++ b/v3/messages.proto
@@ -237,8 +237,6 @@ message UplinkMessage {
 message DownlinkMessage {
   // LoRaWAN region.
   Region region = 10;
-  // LoRaWAN Regional Parameters version to which the data rate indices apply.
-  RegionalParametersVersionValue regional_parameters_version = 11;
 
   // PHYPayload of the downlink message.
   bytes phy_payload = 1;
@@ -269,4 +267,6 @@ message DownlinkMessage {
 
   // Priority of the downlink message.
   DownlinkMessagePriority priority = 8;
+
+  reserved 11; // DEPRECATED: regional_parameters_version
 }

--- a/v3/network.proto
+++ b/v3/network.proto
@@ -17,6 +17,7 @@ syntax = "proto3";
 package org.packetbroker.v3;
 
 import "google/protobuf/timestamp.proto";
+import "google/protobuf/wrappers.proto";
 import "packetbroker/api/v3/contact.proto";
 import "packetbroker/api/v3/enums.proto";
 import "packetbroker/api/v3/target.proto";
@@ -38,6 +39,10 @@ message Network {
   bool listed = 6;
   // Optional target information.
   Target target = 7;
+  // Delegated network.
+  google.protobuf.UInt32Value delegated_net_id = 8;
+  // Networks that this network represents.
+  repeated uint32 represents_net_ids = 9;
 }
 
 message Tenant {


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This adds delegating one network to manage the DevAddr blocks of another via delegation.

One network may represent others. That network can then assign DevAddr blocks in the other ranges as they please.

#### Changes
<!-- What are the changes made in this pull request? -->

- Add messages to manage network delegation
- Unrelated: reserve a now obsolete field; Packet Broker exlusively works with explicit data rates

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

The use case of this higher level delegation is to bring the entire NetID to a provider that can freely allocate DevAddrs.

An example use case is support a Bring Your Own NetID feature to The Things Stack Cloud Plus.

I initially wanted to support DevAddr prefix delegation. This would allow you to lease a block of DevAddrs and let it be managed by another network. I still think this is valuable, but I will do this in a follow up. The use case of this would be to cut a NetID in chunks and let other providers only manage that chunk.
