### PR TITLE
Add caller identity

### DIFF
--- a/iam/v2/service.proto
+++ b/iam/v2/service.proto
@@ -111,6 +111,10 @@ service ClusterAPIKeyVault {
 }
 
 message ListNetworksRequest {
+  // LoRa Alliance NetID of the Member.
+  uint32 net_id = 6;
+  // ID assigned by the Member.
+  string tenant_id = 7;
   // Number of items to skip.
   uint32 offset = 1;
   // Limit the number of items.
@@ -139,6 +143,10 @@ message ListNetworksResponse {
 }
 
 message ListJoinServersRequest {
+  // LoRa Alliance NetID of the Member.
+  uint32 net_id = 4;
+  // ID assigned by the Member.
+  string tenant_id = 5;
   // Number of items to skip.
   uint32 offset = 1;
   // Limit the number of items.

--- a/mapping/v2/openapi.tmpl.json
+++ b/mapping/v2/openapi.tmpl.json
@@ -1,7 +1,7 @@
 {
   "openapi": "3.0.3",
   "info": {
-    "version": "2.2.0",
+    "version": "2.3.0",
     "title": "Packet Broker Mapper",
     "description": "Packet Broker Mapper provides geospatial services for mapping LoRaWAN infrastructure.",
     "contact": {

--- a/mapping/v2/openapi.tmpl.json
+++ b/mapping/v2/openapi.tmpl.json
@@ -22,9 +22,7 @@
   ],
   "security": [
     {
-      "OAuth2": [
-        "networks"
-      ]
+      "OAuth2": ["networks"]
     }
   ],
   "paths": {
@@ -59,11 +57,7 @@
                       "format": "double"
                     }
                   },
-                  "required": [
-                    "latitude",
-                    "longitude",
-                    "distance"
-                  ]
+                  "required": ["latitude", "longitude", "distance"]
                 }
               ]
             },
@@ -92,7 +86,7 @@
           {
             "name": "limit",
             "description": "Number of gateways to return",
-            "in":"query",
+            "in": "query",
             "required": false,
             "schema": {
               "type": "integer",
@@ -124,7 +118,7 @@
             "in": "query",
             "required": false,
             "schema": {
-              "allOf":[
+              "allOf": [
                 {
                   "$ref": "#/components/schemas/NetworkIdentifier"
                 },
@@ -146,7 +140,7 @@
                   "netID": "000013",
                   "tenantID": "ttn"
                 },
-                "summary": "The Things Stack Community Edition"
+                "summary": "The Things Stack Sandbox"
               },
               "the-things-network-eu": {
                 "value": {
@@ -154,7 +148,7 @@
                   "tenantID": "ttn",
                   "clusterID": "eu1.cloud.thethings.network"
                 },
-                "summary": "The Things Stack Community Edition (eu1)"
+                "summary": "The Things Stack Sandbox (eu1)"
               }
             }
           }
@@ -289,14 +283,8 @@
                       "frequencyPlan": {
                         "region": "EU_863_870",
                         "loraMultiSFChannels": [
-                          868100000,
-                          868300000,
-                          868500000,
-                          867100000,
-                          867300000,
-                          867500000,
-                          867700000,
-                          867900000
+                          868100000, 868300000, 868500000, 867100000, 867300000,
+                          867500000, 867700000, 867900000
                         ],
                         "fskChannel": 869525000
                       },
@@ -368,10 +356,7 @@
             "description": "The East-West position (degrees; -180 to +180), where 0 is the Prime Meridian (Greenwich), East is positive, West is negative"
           }
         },
-        "required": [
-          "latitude",
-          "longitude"
-        ]
+        "required": ["latitude", "longitude"]
       },
       "PointZ": {
         "allOf": [
@@ -438,10 +423,7 @@
                 "description": "Gateway ID"
               }
             },
-            "required": [
-              "netID",
-              "id"
-            ]
+            "required": ["netID", "id"]
           }
         ]
       },
@@ -468,11 +450,7 @@
             "minimum": 0
           }
         },
-        "required": [
-          "frequency",
-          "spreadingFactor",
-          "bandwidth"
-        ]
+        "required": ["frequency", "spreadingFactor", "bandwidth"]
       },
       "FrequencyPlan": {
         "type": "object",
@@ -512,9 +490,7 @@
             "$ref": "#/components/schemas/Frequency"
           }
         },
-        "required": [
-          "region"
-        ]
+        "required": ["region"]
       },
       "Gateway": {
         "allOf": [
@@ -542,11 +518,7 @@
                 "$ref": "#/components/schemas/Location"
               },
               "antennaPlacement": {
-                "enum": [
-                  "UNKNOWN_PLACEMENT",
-                  "INDOOR",
-                  "OUTDOOR"
-                ]
+                "enum": ["UNKNOWN_PLACEMENT", "INDOOR", "OUTDOOR"]
               },
               "antennaCount": {
                 "type": "integer",

--- a/mapping/v2/openapi.tmpl.json
+++ b/mapping/v2/openapi.tmpl.json
@@ -1,7 +1,7 @@
 {
   "openapi": "3.0.3",
   "info": {
-    "version": "2.1.0",
+    "version": "2.2.0",
     "title": "Packet Broker Mapper",
     "description": "Packet Broker Mapper provides geospatial services for mapping LoRaWAN infrastructure.",
     "contact": {
@@ -150,6 +150,15 @@
                 },
                 "summary": "The Things Stack Sandbox (eu1)"
               }
+            }
+          },
+          {
+            "name": "homeNetwork",
+            "description": "Return gateways visible to an authenticated Home Network",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "$ref": "#/components/schemas/HomeNetworkIdentifier"
             }
           }
         ],
@@ -408,6 +417,22 @@
           }
         },
         "required": ["netID"]
+      },
+      "HomeNetworkIdentifier": {
+        "type": "object",
+        "properties": {
+          "homeNetworkNetID": {
+            "type": "string",
+            "pattern": "^[0-9A-F]{6}$",
+            "description": "LoRa Alliance NetID (hex)"
+          },
+          "homeNetworkTenantID": {
+            "type": "string",
+            "minLength": 1,
+            "description": "Tenant within the NetID"
+          }
+        },
+        "required": ["homeNetworkNetID"]
       },
       "GatewayIdentifier": {
         "allOf": [


### PR DESCRIPTION

<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This adds the caller network identifier to some request messages.

This is preparing for using authentication mechanisms that require the caller identifier in order to authenticate the caller, i.e. looking up the trust store for the caller.

References https://github.com/packetbroker/iam/issues/21

#### Changes
<!-- What are the changes made in this pull request? -->

- Add caller tenant identifier
- Unrelated: format file and rename to Sandbox

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

This is a compatible API extension. However, requiring these fields to be present is a breaking change in service implementations. We'll announce that as scheduled maintenance.

